### PR TITLE
chore: Update uri for healthcert memo

### DIFF
--- a/src/components/displayDocuments/documents.tsx
+++ b/src/components/displayDocuments/documents.tsx
@@ -93,9 +93,9 @@ export const documents: Document[] = [
   {
     title: "HealthCert Memo",
     uri: uriToAction({
-      uri: window.location.href + "static/documents/healthcerts-memo-notarised.json",
+      uri: "https://notarise.gov.sg/static/documents/healthcerts-memo-notarised.json",
       permittedActions: ["VIEW"],
-      redirect: "https://dev.opencerts.io"
+      redirect: "https://verify.gov.sg/"
     }),
     imageSrc: "/static/img/preview/healthcerts-memo-notarised.png",
     tags: [Tag.HEALTHCERTS]

--- a/src/components/displayDocuments/documents.tsx
+++ b/src/components/displayDocuments/documents.tsx
@@ -93,9 +93,9 @@ export const documents: Document[] = [
   {
     title: "HealthCert Memo",
     uri: uriToAction({
-      uri: "https://healthcerts.gov.sg/documents/healthcerts-memo-notarised.json",
+      uri: "https://www.healthcerts.gov.sg/documents/healthcerts-memo-notarised.json",
       permittedActions: ["VIEW"],
-      redirect: "https://verify.gov.sg/verify"
+      redirect: "https://www.verify.gov.sg/verify"
     }),
     imageSrc: "/static/img/preview/healthcerts-memo-notarised.png",
     tags: [Tag.HEALTHCERTS]

--- a/src/components/displayDocuments/documents.tsx
+++ b/src/components/displayDocuments/documents.tsx
@@ -95,7 +95,7 @@ export const documents: Document[] = [
     uri: uriToAction({
       uri: "https://healthcerts.gov.sg/documents/healthcerts-memo-notarised.json",
       permittedActions: ["VIEW"],
-      redirect: "https://verify.gov.sg/"
+      redirect: "https://verify.gov.sg/verify"
     }),
     imageSrc: "/static/img/preview/healthcerts-memo-notarised.png",
     tags: [Tag.HEALTHCERTS]

--- a/src/components/displayDocuments/documents.tsx
+++ b/src/components/displayDocuments/documents.tsx
@@ -93,7 +93,7 @@ export const documents: Document[] = [
   {
     title: "HealthCert Memo",
     uri: uriToAction({
-      uri: "https://notarise.gov.sg/static/documents/healthcerts-memo-notarised.json",
+      uri: "https://healthcerts.gov.sg/documents/healthcerts-memo-notarised.json",
       permittedActions: ["VIEW"],
       redirect: "https://verify.gov.sg/"
     }),


### PR DESCRIPTION
- Changed to healthcerts.gov.sg to host actual certificate
- Changed redirect to verify.gov.sg