### PR TITLE
feat: generate urls with key in anchor

### DIFF
--- a/src/components/displayDocuments/documents.tsx
+++ b/src/components/displayDocuments/documents.tsx
@@ -12,21 +12,19 @@ interface Action {
   redirect: string;
 }
 
+const stringifyAndEncode = (obj: object): string => window.encodeURIComponent(JSON.stringify(obj));
+
 const uriToAction = ({ uri, key, permittedActions, redirect }: Action): string => {
-  return (
-    "https://action.openattestation.com?q=" +
-    window.encodeURIComponent(
-      JSON.stringify({
-        type: "DOCUMENT",
-        payload: {
-          uri,
-          key,
-          permittedActions,
-          redirect
-        }
-      })
-    )
-  );
+  const action = stringifyAndEncode({
+    type: "DOCUMENT",
+    payload: {
+      uri,
+      permittedActions,
+      redirect
+    }
+  });
+  const anchor = key ? `#${stringifyAndEncode({ key })}` : ``;
+  return `https://action.openattestation.com?q=${action}${anchor}`;
 };
 
 export enum Tag {


### PR DESCRIPTION
As the verifiers are now updated (i.e. able to obtain the key from the anchor), the gallery should also generate URLs with the key in the anchor.