### PR TITLE
feat: remove openattestation actions redirect

### DIFF
--- a/src/components/documents/utils.tsx
+++ b/src/components/documents/utils.tsx
@@ -3,7 +3,8 @@ import { Action } from "./types";
 const stringifyAndEncode = (obj: object): string => window.encodeURIComponent(JSON.stringify(obj));
 
 export const uriToAction = ({ uri, key, permittedActions, redirect, chainId }: Action): string => {
-  const action = stringifyAndEncode({
+  const url = new URL(redirect);
+  const action = {
     type: "DOCUMENT",
     payload: {
       uri,
@@ -11,7 +12,13 @@ export const uriToAction = ({ uri, key, permittedActions, redirect, chainId }: A
       redirect,
       chainId
     }
-  });
-  const anchor = key ? `#${stringifyAndEncode({ key })}` : ``;
-  return `https://action.openattestation.com?q=${action}${anchor}`;
+  };
+
+  url.searchParams.append("q", JSON.stringify(action));
+
+  if (key) {
+    url.hash = `#${stringifyAndEncode({ key })}`;
+  }
+
+  return url.toString();
 };


### PR DESCRIPTION
Remove the pesky OpenAttestation actions redirect that makes a user wait for 3 seconds

![oa actions](https://user-images.githubusercontent.com/37650399/224258252-433f8d02-ec6d-4f42-aed4-b8d56ce30f79.png)