### PR TITLE
fix: unable to download nyc certs

### DIFF
--- a/src/components/documents/documentsNycCerts.tsx
+++ b/src/components/documents/documentsNycCerts.tsx
@@ -19,7 +19,7 @@ const makeNycDocument = ({
         redirect: "https://dev.verify.gov.sg/verify"
       }),
       kind: "did",
-      downloadUrl: `http://document-storage.oa.gov.sg/national-youth-council_${oaFilename}`
+      downloadUrl: `https://document-storage.oa.gov.sg/national-youth-council_${oaFilename}`
     }
   ],
   imageSrc: `/static/img/preview/nyc/${imgFilename}`,


### PR DESCRIPTION
## Why
Can't download NYC certs on chrome (safari seems to work)
https://gallery.openattestation.com/tag/nyc-certs

Likely i suspect is due to a typo such that the download link was to `http` instead of `https`. My understanding is that most modern browsers block any `non https` requests if the origin site itself is served with `https`. This explains why the download work under localhost and not in prod.

## What
Added an `s` in the download link